### PR TITLE
google group fixes

### DIFF
--- a/src/plugins/plugin-catalog-backend-module-google/src/provider/GoogleGroupProvider.ts
+++ b/src/plugins/plugin-catalog-backend-module-google/src/provider/GoogleGroupProvider.ts
@@ -83,6 +83,7 @@ export class GoogleGroupProvider extends GoogleBaseProvider {
             kind: 'Group',
             metadata: {
                 name: group.id as string,
+                title: group.name || undefined,
                 description: group.description || undefined,
                 annotations: {
                     'google.com/group-id': group.id as string,

--- a/src/plugins/plugin-catalog-backend-module-google/src/provider/GoogleGroupProvider.ts
+++ b/src/plugins/plugin-catalog-backend-module-google/src/provider/GoogleGroupProvider.ts
@@ -92,7 +92,7 @@ export class GoogleGroupProvider extends GoogleBaseProvider {
                 }
             },
             spec: {
-                type: 'security-group',
+                type: 'group',
                 children: [],
                 profile: {
                     email: group.email || undefined,


### PR DESCRIPTION
* Make all groups type "group"
  * Can't distinguish security from mailing lists
* set group title so dropdowns make sense 